### PR TITLE
Oil config changes

### DIFF
--- a/lua/primebrook/oil.lua
+++ b/lua/primebrook/oil.lua
@@ -1,7 +1,19 @@
 local M = {}
 
 function M.setup()
-	require("oil").setup()
+	require("oil").setup({
+		use_default_keymaps = false,
+		keymaps = {
+			["<CR>"] = "actions.select",
+			["-"] = "actions.parent",
+		},
+		view_options = {
+			show_hidden = false,
+			is_hidden_file = function(name, bufnr)
+				return vim.startswith(name, "..") or name == ".git" or name == ".vscode"
+			end,
+		},
+	})
 end
 
 return M


### PR DESCRIPTION
1. Remove default keymaps (I keep the useful ones). `<C-p>` was being used for oil previews as when in an oil directory buffer which is annoying because I use that keymap for Telescope's find files.
2. I create a custom definition for hidden files and hide those (i.e. single `.` dotfiles are not considered a hidden file) 
