### PR TITLE
Elixir: Improve function inlining keymap

### DIFF
--- a/lua/primebrook/keymaps/elixir.lua
+++ b/lua/primebrook/keymaps/elixir.lua
@@ -19,7 +19,7 @@ function M.setup()
 	vim.keymap.set("n", "<leader>X", "Orequire IEx ; IEx.pry<Esc>", { noremap = true, silent = true, buffer = true })
 
 	-- Inline function
-	vim.keymap.set("n", "<leader>l", "^f)a,<Esc>$a:<Esc>Jjdd", { noremap = true, silent = true, buffer = true })
+	vim.keymap.set("n", "<leader>l", "^$bhi,<Esc>$a:<Esc>Jjddk^", { noremap = true, silent = true, buffer = true })
 
 	-- Commenting
 	function toggle_comment()


### PR DESCRIPTION
By "inlining a function" (in Elixir) I mean, turning:

this
```elixir
def function(arg1, arg2) do
  "something"
end
```

into this
```elixir
def function(arg1, arg2), do: "something"
```

The keymap for doing this wasn't able to accomodate functions which didn't have arguments (and hence brackets) and functions that did. This updated keymap can handle both.
