### PR TITLE
Add clickhouse format support for `.chsql` files

### DIFF
--- a/ftplugin/chsql.lua
+++ b/ftplugin/chsql.lua
@@ -1,0 +1,2 @@
+vim.bo.syntax = "sql"
+require("primebrook.keymaps.chsql").setup()

--- a/lua/primebrook/init.lua
+++ b/lua/primebrook/init.lua
@@ -6,6 +6,7 @@ function M.setup()
 
 	-- Custom filetypes
 	vim.filetype.add({ extension = { chsql = "chsql" } })
+	vim.treesitter.language.register("sql", "chsql")
 
 	require("primebrook.plugins").setup()
 	require("primebrook.treesitter").setup()

--- a/lua/primebrook/init.lua
+++ b/lua/primebrook/init.lua
@@ -4,6 +4,9 @@ function M.setup()
 	-- Ensure Copilot uses the correct Node.js binary
 	vim.g.copilot_node_command = "/Users/brook/.nvm/versions/node/v22.10.0/bin/node"
 
+	-- Custom filetypes
+	vim.filetype.add({ extension = { chsql = "chsql" } })
+
 	require("primebrook.plugins").setup()
 	require("primebrook.treesitter").setup()
 	require("primebrook.lsp").setup()

--- a/lua/primebrook/keymaps/chsql.lua
+++ b/lua/primebrook/keymaps/chsql.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.setup()
 	-- formatting
-	vim.keymap.set("n", "<leader>ff", ":<C-U>%!clickhouse format<CR>", { noremap = true, silent = true })
+	vim.keymap.set("n", "<leader>ff", ":<C-U>%!/Users/brook/zappi/clickhouse/clickhouse format<CR>", { noremap = true, silent = true })
 end
 
 return M

--- a/lua/primebrook/keymaps/chsql.lua
+++ b/lua/primebrook/keymaps/chsql.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+function M.setup()
+	-- formatting
+	vim.keymap.set("n", "<leader>ff", ":<C-U>%!clickhouse-format<CR>", { noremap = true, silent = true })
+end
+
+return M

--- a/lua/primebrook/keymaps/chsql.lua
+++ b/lua/primebrook/keymaps/chsql.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.setup()
 	-- formatting
-	vim.keymap.set("n", "<leader>ff", ":<C-U>%!clickhouse-format<CR>", { noremap = true, silent = true })
+	vim.keymap.set("n", "<leader>ff", ":<C-U>%!clickhouse format<CR>", { noremap = true, silent = true })
 end
 
 return M


### PR DESCRIPTION
## Summary
- Register `.chsql` as a custom filetype mapped to SQL syntax highlighting
- Add `<leader>ff` keymap for `.chsql` files that runs `clickhouse format`
- `.sql` files continue to use `pg_format` as before

## Test plan
- [x] Open a `.chsql` file and verify SQL syntax highlighting works
- [x] Press `<leader>ff` in a `.chsql` file and verify `clickhouse format` runs
- [x] Open a `.sql` file and verify `pg_format` still runs on `<leader>ff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)